### PR TITLE
Added NSObject as parent class for compatibility with obj-c

### DIFF
--- a/Source/NetworkActivityIndicator.swift
+++ b/Source/NetworkActivityIndicator.swift
@@ -2,7 +2,7 @@
     import UIKit
 #endif
 
-public class NetworkActivityIndicator {
+public class NetworkActivityIndicator:NSObject {
 
     /**
      The shared instance.


### PR DESCRIPTION
Adding NSObject as the parent class allows for integration with objective-c projects.
